### PR TITLE
Fixed compilation error and window flag for i3

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,12 +15,12 @@ int main(int argc, char** argv) {
   QMainWindow window;
   window.resize(358, 192);
   window.setWindowOpacity(0.90);
-  window.setWindowFlags(Qt::FramelessWindowHint);
+  window.setWindowFlags(Qt::FramelessWindowHint | Qt::Dialog);
   window.setWindowIcon(QIcon(":/res/72x72/1f0cf.png"));
 
   EmojiPicker mainWidget;
 
-  QObject::connect(&mainWidget, &EmojiPicker::returnPressed, [&](const auto& emojiStr) {
+  QObject::connect(&mainWidget, &EmojiPicker::returnPressed, [&](const std::string& emojiStr) {
     xdo_enter_text_window(xdo, prevX11Window, emojiStr.data(), 0);
   });
 


### PR DESCRIPTION
Fixed compilation error on newer CMake versions by providing ﻿`std::string` instead of `auto` and added window flag `Qt::Dialog`, so that window with application starts in a popup window on tiling window managers like i3.
