### PR TITLE
Adding gentoo ebuild in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Download the `.deb` from [/releases](https://github.com/GaZaTu/x11-emoji-picker/
 **openSUSE**:
 Download the `.rpm` from [/releases](https://github.com/GaZaTu/x11-emoji-picker/releases) and run `sudo zypper install ./x11-emoji-picker-*.rpm`.
 
+**Gentoo Ebuild**:
+Put an [ebuild](https://gitlab.com/iressa/eonnbuild/-/tree/main/x11-misc/x11-emoji-picker) in the local overlay or otherwise add an overlay with the ebuild and run `emerge x11-misc/x11-emoji-picker`.
+
 **Other**:
 Download the `.AppImage` from [/releases](https://github.com/GaZaTu/x11-emoji-picker/releases), add executable permission (`chmod +x x11-emoji-picker-*.AppImage`) and [run it](#appimage) (Read the usage instructions below).
 


### PR DESCRIPTION
I wrote an ebuild for this repo, tested on Gentoo Linux / dwm, so I stuck a plug in the readme with a bit of instructions that point to it. 👍